### PR TITLE
feat: バックエンドの本番環境対応

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,3 +1,8 @@
 ANTHROPIC_API_KEY=your_anthropic_api_key_here
 OPENAI_API_KEY=your_openai_api_key_here
+SUPABASE_URL=your_supabase_url_here
+SUPABASE_KEY=your_supabase_anon_key_here
 PORT=3000
+ALLOWED_ORIGINS=https://your-frontend-domain.com
+REQUEST_TIMEOUT_MS=30000
+DEMO_MODE=false

--- a/backend/railway.toml
+++ b/backend/railway.toml
@@ -6,3 +6,5 @@ buildCommand = "npm install && npm run build"
 startCommand = "npm start"
 restartPolicyType = "on_failure"
 restartPolicyMaxRetries = 3
+healthcheckPath = "/health"
+healthcheckTimeout = 10

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,20 +1,77 @@
-import express from 'express';
+import express, { Request, Response, NextFunction } from 'express';
 import cors from 'cors';
 import dotenv from 'dotenv';
 import diaryRouter from './routes/diary';
+import weeklyRouter from './routes/weekly';
 
 dotenv.config();
 
 const app = express();
 const PORT = process.env.PORT || 3000;
 
-app.use(cors());
+// CORS設定
+const allowedOrigins = process.env.ALLOWED_ORIGINS
+  ? process.env.ALLOWED_ORIGINS.split(',')
+  : [];
+
+app.use(
+  cors({
+    origin: (origin, callback) => {
+      // モバイルアプリからのリクエスト(originなし)または許可リストに含まれる場合
+      if (!origin || allowedOrigins.length === 0 || allowedOrigins.includes(origin)) {
+        callback(null, true);
+      } else {
+        callback(new Error('Not allowed by CORS'));
+      }
+    },
+  })
+);
+
 app.use(express.json());
 
-app.use('/api/diary', diaryRouter);
+// リクエストタイムアウト（音声処理用に30秒）
+const REQUEST_TIMEOUT_MS = parseInt(process.env.REQUEST_TIMEOUT_MS || '30000', 10);
+app.use((req: Request, res: Response, next: NextFunction) => {
+  res.setTimeout(REQUEST_TIMEOUT_MS, () => {
+    res.status(408).json({ error: 'Request timeout' });
+  });
+  next();
+});
 
-app.listen(PORT, () => {
+// ヘルスチェック
+app.get('/health', (_req: Request, res: Response) => {
+  res.json({ status: 'ok' });
+});
+
+// ルート
+app.use('/api/diary', diaryRouter);
+app.use('/api', weeklyRouter);
+
+// グローバルエラーハンドリング
+app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+  console.error('Unhandled error:', err);
+  res.status(500).json({ error: 'Internal server error' });
+});
+
+const server = app.listen(PORT, () => {
   console.log(`Server running on port ${PORT}`);
 });
+
+// グレースフルシャットダウン
+const shutdown = () => {
+  console.log('Shutting down gracefully...');
+  server.close(() => {
+    console.log('Server closed');
+    process.exit(0);
+  });
+  // 10秒待っても閉じなければ強制終了
+  setTimeout(() => {
+    console.error('Forced shutdown');
+    process.exit(1);
+  }, 10000);
+};
+
+process.on('SIGTERM', shutdown);
+process.on('SIGINT', shutdown);
 
 export default app;


### PR DESCRIPTION
## Summary

- `/health` エンドポイントを追加（Railway死活監視用）
- リクエストタイムアウト30秒を追加（音声処理対応）
- グローバルエラーハンドリングを追加
- グレースフルシャットダウン（SIGTERM/SIGINT）を追加
- CORS設定を `ALLOWED_ORIGINS` 環境変数で制御可能に
- `railway.toml`・`.env.example` を更新

## Test plan
- [ ] `GET /health` が `{"status":"ok"}` を返す
- [ ] Railwayにデプロイして動作確認
- [ ] タイムアウト時に408が返る

🤖 Generated with [Claude Code](https://claude.com/claude-code)